### PR TITLE
fix: マイグレーションでのテーブル削除処理を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/db/migrate/20251223014923_drop_clickups_table.rb
+++ b/db/migrate/20251223014923_drop_clickups_table.rb
@@ -1,5 +1,5 @@
 class DropClickupsTable < ActiveRecord::Migration[8.1]
   def change
-    drop_table :clickups
+    drop_table :clickups, if_exists: true
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the drop-table migration is safe to run multiple times and updates a security scanner dependency.
> 
> - Makes `DropClickupsTable` idempotent by adding `if_exists: true` to `drop_table :clickups`
> - Bumps `brakeman` from `7.1.1` → `7.1.2` in `Gemfile.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792de4eb922581218a18bedf2ffd0f75fcacbe7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->